### PR TITLE
Make blocks easier to use

### DIFF
--- a/ext.js
+++ b/ext.js
@@ -1,54 +1,63 @@
 (function(ext) {
-	ext.gamepadSupport = !!navigator.webkitGetGamepads || !!navigator.webkitGamepads;
-	ext.gamepad = null;
 
-	ext.tick = function() {
-		// poll status
-		ext.gamepad = navigator.webkitGetGamepads && navigator.webkitGetGamepads()[0];
-		window.webkitRequestAnimationFrame(ext.tick);
-	}
+  ext.gamepadSupport = (!!navigator.webkitGetGamepads ||
+                        !!navigator.webkitGamepads);
+  ext.gamepad = null;
 
-	if(ext.gamepadSupport) {
-		window.webkitRequestAnimationFrame(ext.tick);
-	}
+  ext.tick = function() {
+    // poll status
+    ext.gamepad = (navigator.webkitGetGamepads &&
+                   navigator.webkitGetGamepads()[0]);
+    window.webkitRequestAnimationFrame(ext.tick);
+  };
+  if (ext.gamepadSupport) window.webkitRequestAnimationFrame(ext.tick);
 
-	ext._shutdown = function() {};
-	
-	ext._getStatus = function() {
-		if(!ext.gamepadSupport) return { status: 1, msg: "Please use a recent version of Google Chrome"};
-		if(!ext.gamepad) return { status: 1, msg: "Please plug in a gamepad and press any button"};
+  ext._shutdown = function() {};
 
-		return {
-			status: 2,
-			msg: "Good to go!"
-		};
-	}
+  ext._getStatus = function() {
+    if (!ext.gamepadSupport) return {
+      status: 1,
+      msg: "Please use a recent version of Google Chrome",
+    };
 
-	ext.isReady = function() {
-		return !!ext.gamepad;
-	}
+    if (!ext.gamepad) return {
+      status: 1,
+      msg: "Please plug in a gamepad and press any button",
+    };
 
-	ext.getID = function() {
-		return ext.gamepad.id;
-	}
+    return {
+      status: 2,
+      msg: "Good to go!",
+    };
+  };
 
-	ext.getButton = function(btn) {
-		return ext.gamepad.buttons[btn];
-	}
+  ext.isReady = function() {
+    return !!ext.gamepad;
+  };
 
-	ext.getAxis = function(axis) {
-		return ext.gamepad.axes[axis];
-	}
+  ext.getID = function() {
+    return ext.gamepad.id;
+  };
 
-	var descriptor = {
-		blocks: [
-			["r", "ready?", "isReady"],
-			["-"],
-			["r", "gamepad ID", "getID"],
-			["r", "get button %n", "getButton", 0],
-			["r", "get axis %n", "getAxis", 0],
-		]
-	}
+  ext.getButton = function(btn) {
+    return ext.gamepad.buttons[btn];
+  };
 
-	ScratchExtensions.register("Gamepad", descriptor, ext);
+  ext.getAxis = function(axis) {
+    return ext.gamepad.axes[axis];
+  };
+
+  var descriptor = {
+    blocks: [
+      ["r", "ready?", "isReady"],
+    ["-"],
+    ["r", "gamepad ID", "getID"],
+    ["r", "get button %n", "getButton", 0],
+    ["r", "get axis %n", "getAxis", 0],
+    ]
+  };
+
+  ScratchExtensions.register("Gamepad", descriptor, ext);
+
 })({});
+

--- a/ext.js
+++ b/ext.js
@@ -1,16 +1,16 @@
 (function(ext) {
 
-  ext.gamepadSupport = (!!navigator.webkitGetGamepads ||
-                        !!navigator.webkitGamepads);
+  ext.gamepadSupport = (!!navigator.getGamepads ||
+                        !!navigator.gamepads);
   ext.gamepad = null;
 
   ext.tick = function() {
     // poll status
-    ext.gamepad = (navigator.webkitGetGamepads &&
-                   navigator.webkitGetGamepads()[0]);
-    window.webkitRequestAnimationFrame(ext.tick);
+    ext.gamepad = (navigator.getGamepads &&
+                   navigator.getGamepads()[0]);
+    window.requestAnimationFrame(ext.tick);
   };
-  if (ext.gamepadSupport) window.webkitRequestAnimationFrame(ext.tick);
+  if (ext.gamepadSupport) window.requestAnimationFrame(ext.tick);
 
   ext._shutdown = function() {};
 

--- a/ext.js
+++ b/ext.js
@@ -1,11 +1,56 @@
 (function(ext) {
 
+  var DEADZONE = 8000 / 32767;
+
+  var axes = [
+    ["left x", 0],
+    ["left y", 1],
+    ["right x", 2],
+    ["right y", 3],
+  ];
+  var buttons = [
+    ["left top", 4],
+    ["left bottom", 6],
+    ["right top", 5],
+    ["right bottom", 7],
+    ["left stick", 10],
+    ["right stick", 11],
+    ["A", 0],
+    ["B", 1],
+    ["X", 2],
+    ["Y", 3],
+    ["select", 8],
+    ["start", 9],
+    ["up", 12],
+    ["down", 13],
+    ["left", 14],
+    ["right", 15],
+  ];
+
+  var menus = {
+    axis: [],
+    button: [],
+  };
+  var axisNames = {};
+  var buttonNames = {};
+  axes.forEach(function(d) {
+    var name = d[0],
+        index = d[1];
+    menus.axis.push(name);
+    axisNames[name] = index;
+  });
+  buttons.forEach(function(d) {
+    var name = d[0],
+        index = d[1];
+    menus.button.push(name);
+    buttonNames[name] = index;
+  });
+
   ext.gamepadSupport = (!!navigator.getGamepads ||
                         !!navigator.gamepads);
   ext.gamepad = null;
 
   ext.tick = function() {
-    // poll status
     ext.gamepad = (navigator.getGamepads &&
                    navigator.getGamepads()[0]);
     window.requestAnimationFrame(ext.tick);
@@ -31,30 +76,26 @@
     };
   };
 
-  ext.isReady = function() {
-    return !!ext.gamepad;
+  ext.getButton = function(name) {
+    var index = buttonNames[name];
+    var button = ext.gamepad.buttons[index];
+    return button.pressed;
   };
 
-  ext.getID = function() {
-    return ext.gamepad.id;
-  };
-
-  ext.getButton = function(btn) {
-    return ext.gamepad.buttons[btn];
-  };
-
-  ext.getAxis = function(axis) {
-    return ext.gamepad.axes[axis];
+  ext.getAxis = function(name) {
+    var index = axisNames[name];
+    var value = ext.gamepad.axes[index];
+    if (-DEADZONE < value && value < DEADZONE) value = 0;
+    if (index === 1 || index === 3) value = -value;
+    return value * 100;
   };
 
   var descriptor = {
     blocks: [
-      ["r", "ready?", "isReady"],
-    ["-"],
-    ["r", "gamepad ID", "getID"],
-    ["r", "get button %n", "getButton", 0],
-    ["r", "get axis %n", "getAxis", 0],
-    ]
+      ["b", "button %m.button pressed?", "getButton", "X"],
+      ["r", "axis %m.axis", "getAxis", "left x"],
+    ],
+    menus: menus,
   };
 
   ScratchExtensions.register("Gamepad", descriptor, ext);


### PR DESCRIPTION
This improves the user-facing API to include menu options for button names.

It also reports direction/force instead of x/y, which I believe makes the extension easier to work with.
- `〈button [start ▾] pressed?〉`
- `([direction ▾] of [left ▾] stick)`
