### PR TITLE
4 new blocks, New menu options, Direction fix & Design Changes

### DIFF
--- a/ext.js
+++ b/ext.js
@@ -121,7 +121,7 @@
   
   ext.whichButton = function() {
     var result = buttons[ext.gamepad.buttons.map(function(e) {return e.pressed;}).indexOf(true)];
-    if(typeof result != "undefined") {
+    if(typeof result == "undefined") {
       result = -1;
     }
     return result;

--- a/ext.js
+++ b/ext.js
@@ -66,7 +66,7 @@
   
   var hatFix = [false, false]; //Auto-reset hat
   ext.hatButton = function(name) {
-    if(!hatFix[0] && ext.getButton(name) == true) {
+    if(!hatFix[0] && ext.getButton(name) === true) {
         hatFix[0] = true;
         return true;
     } else {
@@ -83,7 +83,7 @@
         hatFix[1] = false;
         return false;
     }
-  }
+  };
 
   ext.getButton = function(name) {
     if(name != "any") {
@@ -120,10 +120,9 @@
   };
   
   ext.whichButton = function() {
-    try {
-      var result = buttons[ext.gamepad.buttons.map(function(e) {return e.pressed;}).indexOf(true)];
-    } catch (e) {
-      var result = -1;
+    var result = buttons[ext.gamepad.buttons.map(function(e) {return e.pressed;}).indexOf(true)];
+    if(typeof result != "undefined") {
+      result = -1;
     }
     return result;
   };

--- a/ext.js
+++ b/ext.js
@@ -7,10 +7,10 @@
     "B",
     "X",
     "Y",
-    "left top",
-    "left bottom",
-    "right top",
-    "right bottom",
+    "left button",
+    "right button",
+    "left trigger",
+    "right trigger",
     "select",
     "start",
     "left stick",
@@ -21,12 +21,15 @@
     "right"
   ];
 
-  var buttonMenu = ["any"];
+  var buttonMenu = [];
   var buttonNames = {};
   buttons.forEach(function(name, i) {
     buttonMenu.push(name);
     buttonNames[name] = i;
   });
+  buttonMenu.splice(8, 0, "left trigger (fully pressed)");
+  buttonMenu.splice(9, 0, "right trigger (fully pressed)");
+  buttonMenu.push("any", "any (fully pressed)");
 
   ext.gamepadSupport = (!!navigator.getGamepads ||
                         !!navigator.gamepads);
@@ -86,15 +89,29 @@
   };
 
   ext.getButton = function(name) {
-    if(name != "any") {
+    if(name == "left trigger (fully pressed)") {
+      return ext.gamepad.buttons[6].value == 1;
+    }
+    if(name == "right trigger (fully pressed)") {
+      return ext.gamepad.buttons[7].value == 1;
+    }
+    if(name.indexOf("any") == -1) {
       var index = buttonNames[name];
       var button = ext.gamepad.buttons[index];
       return button.pressed;
     } else {
-      //Test if any of the "pressed' property of the objects inside the array ext.gamepad.buttons matches true
-      return ext.gamepad.buttons.map(function(e) { return e.pressed; }).indexOf(true) > -1;
+      if(name == "any") {
+        return ext.gamepad.buttons.map(function(e) { return e.pressed; }).indexOf(true) > -1;
+      } else {
+        return ext.gamepad.buttons.map(function(e) { return e.value; }).indexOf(1) > -1;
+      }
     }
   };
+  
+  ext.getTrigger = function(which) {
+    which = (which == "left trigger") ? 6 : 7;
+    return ext.gamepad.buttons[which].value;
+  }
 
   ext.getStick = function(what, stick) {
     var x, y;
@@ -135,6 +152,7 @@
       ["h", "when %m.stick stick points at any direction", "hatStick", "left"],
       ["-"],
       ["b", "button %m.button pressed?", "getButton", "A"],
+      ["r", "% pressed of %m.trigger", "getTrigger", "left trigger"],
       ["r", "%m.axisValue of %m.stick stick", "getStick", "direction", "left"],
       ["-"],
       ["r", "Which button is pressed?", "whichButton"]
@@ -142,6 +160,7 @@
     menus: {
       button: buttonMenu,
       stick: ["left", "right"],
+      trigger: ["left trigger", "right trigger"],
       axisValue: ["direction", "force"],
     },
   };

--- a/ext.js
+++ b/ext.js
@@ -27,9 +27,9 @@
     buttonMenu.push(name);
     buttonNames[name] = i;
   });
-  buttonMenu.splice(8, 0, "left trigger (fully pressed)");
-  buttonMenu.splice(9, 0, "right trigger (fully pressed)");
-  buttonMenu.push("any", "any (fully pressed)");
+  buttonMenu.splice(8, 0, "left trigger (100%)");
+  buttonMenu.splice(9, 0, "right trigger (100%)");
+  buttonMenu.push("any", "any (100%)");
 
   ext.gamepadSupport = (!!navigator.getGamepads ||
                         !!navigator.gamepads);
@@ -67,7 +67,7 @@
     return true;
   };
   
-  var hatFix = [false, false]; //Auto-reset hat
+  var hatFix = [false, false]; //Auto-reset hats
   ext.hatButton = function(name) {
     if(!hatFix[0] && ext.getButton(name) === true) {
         hatFix[0] = true;
@@ -89,10 +89,10 @@
   };
 
   ext.getButton = function(name) {
-    if(name == "left trigger (fully pressed)") {
+    if(name == "left trigger (100%)") {
       return ext.gamepad.buttons[6].value == 1;
     }
-    if(name == "right trigger (fully pressed)") {
+    if(name == "right trigger (100%)") {
       return ext.gamepad.buttons[7].value == 1;
     }
     if(name.indexOf("any") == -1) {

--- a/ext.js
+++ b/ext.js
@@ -115,7 +115,7 @@
         ext.stickDirection[stick] = value;
         return value;
       case "force":
-        return Math.sqrt(x*x + y*y) * 100;
+        return Math.sqrt(x*x + y*y);
     }
   };
   

--- a/ext.js
+++ b/ext.js
@@ -109,7 +109,7 @@
   };
   
   ext.getTrigger = function(which) {
-    which = (which == "left trigger") ? 6 : 7;
+    which = (which == "left") ? 6 : 7;
     return ext.gamepad.buttons[which].value;
   }
 
@@ -152,7 +152,7 @@
       ["h", "when %m.stick stick points at any direction", "hatStick", "left"],
       ["-"],
       ["b", "button %m.button pressed?", "getButton", "A"],
-      ["r", "% pressed of %m.trigger", "getTrigger", "left trigger"],
+      ["r", "% pressed of %m.stick trigger", "getTrigger", "left trigger"],
       ["r", "%m.axisValue of %m.stick stick", "getStick", "direction", "left"],
       ["-"],
       ["r", "Which button is pressed?", "whichButton"]
@@ -160,7 +160,6 @@
     menus: {
       button: buttonMenu,
       stick: ["left", "right"],
-      trigger: ["left trigger", "right trigger"],
       axisValue: ["direction", "force"],
     },
   };


### PR DESCRIPTION
Added: "when button \* pressed",
           "when \* stick points at any direction"
           "Which button is pressed?"
           "any option in buttonMenu, as well as 3 more options to check if buttons are 100% pressed"
getButton() now returns false when the player isn't using the stick (the old way didn't allow you to            detect it inside Scratch).
All button names are now defaulted to Xbox's ones.

Each block of the extension should have an option to choose which gamepad is going to be used, but I am too lazy to do it right now :/

Btw, can I merge this with my extension? http://scratch.mit.edu/discuss/topic/77718/
